### PR TITLE
Convert python2 code to python3.

### DIFF
--- a/rtc-video-quality/generate_data.py
+++ b/rtc-video-quality/generate_data.py
@@ -384,7 +384,7 @@ def add_framestats(results_dict, framestats_file, statstype):
   with open(framestats_file) as csvfile:
     reader = csv.DictReader(csvfile)
     for row in reader:
-      for (metric, value) in list(row.items()):
+      for (metric, value) in row.items():
         metric_key = 'frame-%s' % metric
         if metric_key not in results_dict:
           results_dict[metric_key] = []

--- a/rtc-video-quality/generate_graphs.py
+++ b/rtc-video-quality/generate_graphs.py
@@ -45,7 +45,7 @@ def split_data(graph_data, attribute):
     if value not in groups:
       groups[value] = []
     groups[value].append(element)
-  return list(groups.values())
+  return groups.values()
 
 def normalize_bitrate_config_string(config):
   return ":".join([str(int(x * 100.0 / config[-1])) for x in config])

--- a/rtc-video-quality/generate_graphs.py
+++ b/rtc-video-quality/generate_graphs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,7 +45,7 @@ def split_data(graph_data, attribute):
     if value not in groups:
       groups[value] = []
     groups[value].append(element)
-  return groups.values()
+  return list(groups.values())
 
 def normalize_bitrate_config_string(config):
   return ":".join([str(int(x * 100.0 / config[-1])) for x in config])
@@ -138,8 +138,8 @@ def main():
 
   current_graph = 1
   total_graphs = len(graph_dict)
-  for (subdir, graph_name), lines in graph_dict.iteritems():
-    print "[%d/%d] %s" % (current_graph, total_graphs, graph_name)
+  for (subdir, graph_name), lines in graph_dict.items():
+    print("[%d/%d] %s" % (current_graph, total_graphs, graph_name))
     current_graph += 1
     metric = graph_name.split(':')[-1]
     fig, ax = plt.subplots()


### PR DESCRIPTION
Since python2 is deprecated and no longer supported, we will be
converting the all the code used to python3. Used a tool (2to3) to
convert most of the print/dictionary statements to python3. With
python3,some of the functions returned bytes by default instead of
string. Thus we had to manually add encoding to utf-8 in subprocess commands.