### PR TITLE
Add encoder configurations

### DIFF
--- a/rtc-video-quality/binary_vars.py
+++ b/rtc-video-quality/binary_vars.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 # Encoder Binaries
+RAV1E_ENC_BIN = 'rav1e/target/release/rav1e'
+SVT_ENC_BIN = 'SVT-AV1/Bin/Release/SvtAv1EncApp'
 AOM_ENC_BIN = 'aom/aom_build/aomenc'
 VPX_ENC_BIN = 'libvpx/vpxenc'
 H264_ENC_BIN = 'openh264/h264enc'

--- a/rtc-video-quality/encoder_commands.py
+++ b/rtc-video-quality/encoder_commands.py
@@ -409,7 +409,7 @@ def yami_command(job, temp_dir):
 def get_encoder_command(encoder):
     encoders = [
         'aom-good', 'aom-rt', 'aom-all_intra', 'aom-offline', ## AOM CONFIGS
-        'rav1e-1pass', 'rav1e-rt', 'rav1e-all_intra', ## RAV1E CONFIGS TODO: FIXME
+        'rav1e-1pass', 'rav1e-rt', 'rav1e-all_intra', ## RAV1E CONFIGS
         'svt-1pass', 'svt-rt', 'svt-all_intra', ## SVT CONFIGS
         'openh264', ## OPENH264 CONFIGS
         'libvpx-rt', ## LIBVPX CONFIGS

--- a/rtc-video-quality/encoder_commands.py
+++ b/rtc-video-quality/encoder_commands.py
@@ -18,14 +18,131 @@ import subprocess
 import tempfile
 from binary_vars import *
 
+
 libvpx_threads = 4
+
+INTRA_IVAL_LOW_LATENCY = 60
+
+RAV1E_SPEED = 4
+SVT_SPEED = 2
+AOM_SPEED = 2
+
+AOM_RT_SPEED = 5
+RAV1E_RT_SPEED = 7
+SVT_RT_SPEED = 5
+
+def rav1e_command(job, temp_dir):
+    assert job['num_spatial_layers'] == 1
+    assert job['num_temporal_layers'] == 1
+    assert job['codec'] == 'av1'
+    assert job['encoder'] in ['rav1e-1pass', 'rav1e-rt', 'rav1e-all_intra']
+
+    (fd, encoded_filename) = tempfile.mkstemp(dir=temp_dir, suffix=".ivf")
+    os.close(fd)
+
+    clip = job['clip']
+    fps = int(clip['fps'] + 0.5)
+
+    common_params = [
+        '-y',
+        '--output', encoded_filename,
+        '--bitrate', job['target_bitrates_kbps'][0],
+        clip['y4m_file']
+    ]
+
+
+    encoder = job['encoder']
+
+    if encoder == 'rav1e-1pass':
+        codec_params = [
+            '--speed', RAV1E_SPEED,
+            '--low-latency',
+            '--keyint', INTRA_IVAL_LOW_LATENCY
+        ]
+    elif encoder == 'rav1e-rt':
+        codec_params = [
+            '--low-latency',
+            '--speed', RAV1E_RT_SPEED,
+            '--keyint', INTRA_IVAL_LOW_LATENCY
+        ]
+    elif encoder == 'rav1e-all_intra':
+        codec_params = [
+            '--speed', '4',
+            '--keyint', '1'
+        ]
+
+    command = [RAV1E_ENC_BIN] + codec_params + common_params
+
+    command = [str(flag) for flag in command]
+
+    encoded_files = [{'spatial-layer': 0,
+                      'temporal-layer': 0, 'filename': encoded_filename
+                      }]
+
+    return command, encoded_files
+
+
+def svt_command(job, temp_dir):
+    assert job['num_spatial_layers'] == 1
+    assert job['num_temporal_layers'] == 1
+    assert job['codec'] == 'av1'
+    assert job['encoder'] in ['svt-1pass', 'svt-rt', 'svt-all_intra']
+
+    (fd, encoded_filename) = tempfile.mkstemp(dir=temp_dir, suffix=".ivf")
+    os.close(fd)
+
+    clip = job['clip']
+    fps = int(clip['fps'] + 0.5)
+
+    common_params = [
+        '--fps', fps,
+        '-w', clip['width'],
+        '-h', clip['height'],
+        '-i', clip['yuv_file'],
+        '-b', encoded_filename,
+        '--tbr', job['target_bitrates_kbps'][0]
+    ]
+
+    encoder = job['encoder']
+
+    if encoder == 'svt-1pass':
+
+        codec_params = [
+            '--preset', "8",
+        ]
+    elif encoder == 'svt-rt':
+
+        codec_params = [
+            '--scm', 0,
+            '--lookahead', 0,
+            '--preset', SVT_RT_SPEED,
+            '--keyint', (INTRA_IVAL_LOW_LATENCY - 1)
+        ]
+
+    elif encoder == 'svt-all_intra':
+
+        codec_params = [
+            '--scm', 0,
+            '--keyint', 0,
+            '--preset', SVT_SPEED,
+        ]
+
+    command = [SVT_ENC_BIN] + codec_params + common_params
+
+    command = [str(flag) for flag in command]
+
+    encoded_files = [{'spatial-layer': 0,
+                      'temporal-layer': 0, 'filename': encoded_filename
+                      }]
+
+    return command, encoded_files
+
 
 def aom_command(job, temp_dir):
     assert job['num_spatial_layers'] == 1
     assert job['num_temporal_layers'] == 1
     assert job['codec'] == 'av1'
-    # TODO(pbos): Add realtime config (aom-rt) when AV1 is realtime ready.
-    assert job['encoder'] == 'aom-good'
+    assert job['encoder'] in ['aom-good', 'aom-rt', 'aom-all_intra', 'aom-offline']
 
     (fd, first_pass_file) = tempfile.mkstemp(dir=temp_dir, suffix=".fpf")
     os.close(fd)
@@ -35,40 +152,99 @@ def aom_command(job, temp_dir):
 
     clip = job['clip']
     fps = int(clip['fps'] + 0.5)
-    command = [
-      AOM_ENC_BIN,
-      "--codec=av1",
-      "-p", "2",
-      "--fpf=%s" % first_pass_file,
-      "--good",
-      "--cpu-used=0",
-      "--target-bitrate=%d" % job['target_bitrates_kbps'][0],
-      '--fps=%d/1' % fps,
-      "--lag-in-frames=25",
-      "--min-q=0",
-      "--max-q=63",
-      "--auto-alt-ref=1",
-      "--kf-max-dist=150",
-      "--kf-min-dist=0",
-      "--drop-frame=0",
-      "--static-thresh=0",
-      "--bias-pct=50",
-      "--minsection-pct=0",
-      "--maxsection-pct=2000",
-      "--arnr-maxframes=7",
-      "--arnr-strength=5",
-      "--sharpness=0",
-      "--undershoot-pct=100",
-      "--overshoot-pct=100",
-      "--frame-parallel=0",
-      "--tile-columns=0",
-      "--profile=0",
-      '--width=%d' % clip['width'],
-      '--height=%d' % clip['height'],
-      '--output=%s' % encoded_filename,
-      clip['yuv_file'],
+
+    common_params = [
+        '--codec=av1',
+        '--width=%d' % clip['width'],
+        '--height=%d' % clip['height'],
+        '--output=%s' % encoded_filename,
+        '--target-bitrate=%d' % job['target_bitrates_kbps'][0],
+        clip['yuv_file']
     ]
-    encoded_files = [{'spatial-layer': 0, 'temporal-layer': 0, 'filename': encoded_filename}]
+
+    encoder = job['encoder']
+
+    if encoder == 'aom-good':
+        codec_params = [
+            '--good',
+            "-p", "2",
+            "--lag-in-frames=25",
+            '--cpu-used=3',
+            "--auto-alt-ref=1",
+            "--kf-max-dist=150",
+            "--kf-min-dist=0",
+            "--drop-frame=0",
+            "--static-thresh=0",
+            "--bias-pct=50",
+            "--minsection-pct=0",
+            "--maxsection-pct=2000",
+            "--arnr-maxframes=7",
+            "--arnr-strength=5",
+            "--sharpness=0",
+            "--undershoot-pct=100",
+            "--overshoot-pct=100",
+            "--frame-parallel=0",
+            "--tile-columns=0",
+            "--profile=0"
+        ]
+
+    elif encoder == 'aom-all_intra':
+        codec_params = [
+            '--cpu-used=4',
+            '--kf-max-dist=1',
+            '--end-usage=q'
+        ]
+    elif encoder == 'aom-rt':
+        codec_params = [
+            '--cpu-used=%d' % AOM_RT_SPEED,
+            '--disable-warning-prompt',
+            '--enable-tpl-model=0',
+            '--deltaq-mode=0',
+            '--sb-size=0',
+            '--ivf',
+            '--profile=0',
+            '--static-thresh=0',
+            '--undershoot-pct=50',
+            '--overshoot-pct=50',
+            '--buf-sz=1000',
+            '--buf-initial-sz=500',
+            '--buf-optimal-sz=600',
+            '--max-intra-rate=300',
+            '--passes=1',
+            '--rt',
+            '--lag-in-frames=0',
+            '--noise-sensitivity=0',
+            '--error-resilient=1',
+        ]
+    elif encoder == 'aom-offline':
+        codec_params = [
+            '--good',
+            "--passes=2",
+            '--threads=0',
+            "--lag-in-frames=25",
+            '--cpu-used=%d' % AOM_SPEED,
+            "--auto-alt-ref=1",
+            "--kf-max-dist=150",
+            "--kf-min-dist=0",
+            "--drop-frame=0",
+            "--static-thresh=0",
+            "--bias-pct=50",
+            "--minsection-pct=0",
+            "--maxsection-pct=2000",
+            "--arnr-maxframes=7",
+            "--arnr-strength=5",
+            "--sharpness=0",
+            "--undershoot-pct=25",
+            "--overshoot-pct=25",
+            "--frame-parallel=1",
+            "--tile-columns=3",
+            "--profile=0"
+        ]
+
+    command = [AOM_ENC_BIN] + codec_params + common_params
+
+    encoded_files = [{'spatial-layer': 0,
+                      'temporal-layer': 0, 'filename': encoded_filename}]
     return (command, encoded_files)
 
 def libvpx_tl_command(job, temp_dir):
@@ -230,9 +406,28 @@ def yami_command(job, temp_dir):
     encoded_files = [{'spatial-layer': 0, 'temporal-layer': 0, 'filename': encoded_filename}]
     return ([str(i) for i in command], encoded_files)
 
-encoder_commands = {
-  'aom-good' : aom_command,
-  'openh264' : openh264_command,
-  'libvpx-rt' : libvpx_command,
-  'yami' : yami_command,
-}
+def get_encoder_command(encoder):
+    encoders = [
+        'aom-good', 'aom-rt', 'aom-all_intra', 'aom-offline', ## AOM CONFIGS
+        'rav1e-1pass', 'rav1e-rt', 'rav1e-all_intra', ## RAV1E CONFIGS TODO: FIXME
+        'svt-1pass', 'svt-rt', 'svt-all_intra', ## SVT CONFIGS
+        'openh264', ## OPENH264 CONFIGS
+        'libvpx-rt', ## LIBVPX CONFIGS
+        'yami' ## YAMI CONFIGS
+    ]
+
+    if encoder not in encoders:
+        return None
+
+    if 'aom' in encoder:
+        return aom_command
+    elif 'rav1e' in encoder:
+        return rav1e_command
+    elif 'svt' in encoder:
+        return svt_command
+    elif 'libvpx' in encoder:
+        return libvpx_command
+    elif 'openh264' in encoder:
+        return openh264_command
+    elif 'yami' in encoder:
+        return yami_command

--- a/rtc-video-quality/generate_data.py
+++ b/rtc-video-quality/generate_data.py
@@ -209,6 +209,18 @@ def prepare_clips(args, temp_dir):
                         total_filesize -= blocksize
             clip['yuv_file'] = truncated_filename
 
+        (fd, y4m_file) = tempfile.mkstemp(dir=temp_dir, suffix='.y4m')
+        os.close(fd)
+
+        with open(os.devnull, 'w') as devnull:
+            subprocess.check_call(
+                ['ffmpeg', '-y', '-s', '%dx%d' % (clip['width'], clip['height']), '-r', str(int(clip['fps'] + 0.5)), '-pix_fmt', 'yuv420p', '-i', clip['yuv_file'], y4m_file],
+                stdout=devnull,
+                stderr=devnull
+            )
+
+        clip['y4m_file'] = y4m_file
+
 
 def decode_file(job, temp_dir, encoded_file):
     (fd, decoded_file) = tempfile.mkstemp(dir=temp_dir, suffix=".yuv")

--- a/rtc-video-quality/generate_data.py
+++ b/rtc-video-quality/generate_data.py
@@ -113,7 +113,7 @@ def encoder_pairs(string):
             raise argparse.ArgumentTypeError(
                 "Argument '%s' of '%s' doesn't match input format.\n" %
                 (pair, string))
-        if not pair_match.group(1) in encoder_commands:
+        if not get_encoder_command(pair_match.group(1)):
             raise argparse.ArgumentTypeError(
                 "Unknown encoder: '%s' in pair '%s'\n" %
                 (pair_match.group(1), pair))
@@ -441,7 +441,7 @@ def generate_jobs(args, temp_dir):
                 }
                 job_temp_dir = tempfile.mkdtemp(dir=temp_dir)
                 (command,
-                 encoded_files) = encoder_commands[job['encoder']](job,
+                 encoded_files) = get_encoder_command(job['encoder'])(job,
                                                                    job_temp_dir)
                 command[0] = find_absolute_path(args.use_system_path,
                                                 command[0])

--- a/rtc-video-quality/generate_data.py
+++ b/rtc-video-quality/generate_data.py
@@ -213,11 +213,14 @@ def prepare_clips(args, temp_dir):
         os.close(fd)
 
         with open(os.devnull, 'w') as devnull:
-            subprocess.check_call(
-                ['ffmpeg', '-y', '-s', '%dx%d' % (clip['width'], clip['height']), '-r', str(int(clip['fps'] + 0.5)), '-pix_fmt', 'yuv420p', '-i', clip['yuv_file'], y4m_file],
-                stdout=devnull,
-                stderr=devnull
-            )
+            subprocess.check_call([
+                'ffmpeg', '-y', '-s',
+                '%dx%d' % (clip['width'], clip['height']), '-r',
+                str(int(clip['fps'] + 0.5)), '-pix_fmt', 'yuv420p', '-i',
+                clip['yuv_file'], y4m_file
+            ],
+                                  stdout=devnull,
+                                  stderr=devnull)
 
         clip['y4m_file'] = y4m_file
 
@@ -456,9 +459,8 @@ def generate_jobs(args, temp_dir):
                         args.num_temporal_layers,
                 }
                 job_temp_dir = tempfile.mkdtemp(dir=temp_dir)
-                (command,
-                 encoded_files) = get_encoder_command(job['encoder'])(job,
-                                                                   job_temp_dir)
+                (command, encoded_files) = get_encoder_command(job['encoder'])(
+                    job, job_temp_dir)
                 command[0] = find_absolute_path(args.use_system_path,
                                                 command[0])
                 jobs.append((job, (command, encoded_files), job_temp_dir))


### PR DESCRIPTION
# Add different encoder configurations

* Added configurations for svt-rt and rav1e-rt in `encoder_commands`
* Updated a way to get associated encoder_command by using a function instead of dictionary 
* Add binary constants for svt-rt and rav1e

Since rav1e only accepts y4m videos as inputs, add a process to always
convert yuv to y4m and pass that as input to rav1e.