### PR TITLE
Add offline configurations for SVT-AV1.

### DIFF
--- a/rtc-video-quality/encoder_commands.py
+++ b/rtc-video-quality/encoder_commands.py
@@ -86,7 +86,7 @@ def svt_command(job, temp_dir):
     assert job['num_spatial_layers'] == 1
     assert job['num_temporal_layers'] == 1
     assert job['codec'] == 'av1'
-    assert job['encoder'] in ['svt-1pass', 'svt-rt', 'svt-all_intra']
+    assert job['encoder'] in ['svt-1pass', 'svt-rt', 'svt-offline', 'svt-all_intra']
 
     (fd, encoded_filename) = tempfile.mkstemp(dir=temp_dir, suffix=".ivf")
     os.close(fd)
@@ -127,7 +127,34 @@ def svt_command(job, temp_dir):
             '--preset', SVT_SPEED,
         ]
 
-    command = [binary_vars.SVT_ENC_BIN] + codec_params + common_params
+    elif encoder == 'svt-offline':
+
+        (fd, statfile) = tempfile.mkstemp(dir=temp_dir, suffix='.stat')
+        os.close(fd)
+
+        first_pass_params = [
+            '--scm', 0,
+            '--keyint', (INTRA_IVAL_LOW_LATENCY -1),
+            '--preset', 8,
+            '--output-stat-file', statfile
+        ]
+
+        second_pass_params = [
+            '--scm', 0,
+            '--keyint', (INTRA_IVAL_LOW_LATENCY - 1),
+            '--preset', SVT_SPEED,
+            '--input-stat-file', statfile
+        ]
+
+    if 'offline' in encoder:
+        first_pass_command = [ binary_vars.SVT_ENC_BIN ] + first_pass_params + common_params
+        second_pass_command = [ binary_vars.SVT_ENC_BIN ] + second_pass_params + common_params
+
+        command = first_pass_command + ['&&'] + second_pass_command
+
+    else:
+
+        command = [binary_vars.SVT_ENC_BIN] + codec_params + common_params
 
     command = [str(flag) for flag in command]
 
@@ -410,7 +437,7 @@ def get_encoder_command(encoder):
     encoders = [
         'aom-good', 'aom-rt', 'aom-all_intra', 'aom-offline', ## AOM CONFIGS
         'rav1e-1pass', 'rav1e-rt', 'rav1e-all_intra', ## RAV1E CONFIGS
-        'svt-1pass', 'svt-rt', 'svt-all_intra', ## SVT CONFIGS
+        'svt-1pass', 'svt-rt', 'svt-all_intra', 'svt-offline', ## SVT CONFIGS
         'openh264', ## OPENH264 CONFIGS
         'libvpx-rt', ## LIBVPX CONFIGS
         'yami' ## YAMI CONFIGS

--- a/rtc-video-quality/generate_data.py
+++ b/rtc-video-quality/generate_data.py
@@ -468,7 +468,8 @@ def generate_jobs(args, temp_dir):
                 full_command = find_absolute_path(args.use_system_path,
                                                   command[0])
                 command = [
-                    word.replace(command[0], full_command) for word in command
+                    full_command if word == command[0] else word
+                    for word in command
                 ]
                 jobs.append((job, (command, encoded_files), job_temp_dir))
     return jobs

--- a/rtc-video-quality/generate_data.py
+++ b/rtc-video-quality/generate_data.py
@@ -26,6 +26,7 @@ import sys
 import tempfile
 import threading
 import time
+import shlex
 
 from encoder_commands import *
 import binary_vars
@@ -349,7 +350,8 @@ def run_command(job, encoder_command, job_temp_dir, encoded_file_dir):
     clip = job['clip']
     start_time = time.time()
     try:
-        process = subprocess.Popen(' '.join(command),
+        process = subprocess.Popen(' '.join(
+            shlex.quote(arg) if arg != '&&' else arg for arg in command),
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.STDOUT,
                                    encoding='utf-8',

--- a/rtc-video-quality/generate_data.py
+++ b/rtc-video-quality/generate_data.py
@@ -349,9 +349,11 @@ def run_command(job, encoder_command, job_temp_dir, encoded_file_dir):
     clip = job['clip']
     start_time = time.time()
     try:
-        process = subprocess.Popen(command,
+        process = subprocess.Popen(' '.join(command),
                                    stdout=subprocess.PIPE,
-                                   stderr=subprocess.STDOUT)
+                                   stderr=subprocess.STDOUT,
+                                   encoding='utf-8',
+                                   shell=True)
     except OSError as e:
         return (None, "> %s\n%s" % (" ".join(command), e))
     (output, _) = process.communicate()
@@ -461,8 +463,11 @@ def generate_jobs(args, temp_dir):
                 job_temp_dir = tempfile.mkdtemp(dir=temp_dir)
                 (command, encoded_files) = get_encoder_command(job['encoder'])(
                     job, job_temp_dir)
-                command[0] = find_absolute_path(args.use_system_path,
-                                                command[0])
+                full_command = find_absolute_path(args.use_system_path,
+                                                  command[0])
+                command = [
+                    word.replace(command[0], full_command) for word in command
+                ]
                 jobs.append((job, (command, encoded_files), job_temp_dir))
     return jobs
 


### PR DESCRIPTION
In order to run SVT 2 pass, you need to run 2 seperate commands and use
a statfile. Thus, the command for Popen was changed to use shell so that
it supports shell symbols such as '&&'. So currently, svt_command can
return a command of the form command1 + ['&&'] + command2 where command1
and command2 are list of strings.