### PR TITLE
Add more flags to SVT so that it is similar to libaom

### DIFF
--- a/rtc-video-quality/encoder_commands.py
+++ b/rtc-video-quality/encoder_commands.py
@@ -95,6 +95,7 @@ def svt_command(job, temp_dir):
     fps = int(clip['fps'] + 0.5)
 
     common_params = [
+        '--profile', 0,
         '--fps', fps,
         '-w', clip['width'],
         '-h', clip['height'],
@@ -143,6 +144,10 @@ def svt_command(job, temp_dir):
             '--scm', 0,
             '--keyint', (INTRA_IVAL_LOW_LATENCY - 1),
             '--preset', SVT_SPEED,
+            '--tile-columns', 3,
+            '--enable-altrefs', 1,
+            '--altref-nframes', 7,
+            '--altref-strength', 5,
             '--input-stat-file', statfile
         ]
 


### PR DESCRIPTION
Add similar flags for svt configurations that are currently being used by libaom.  
The flags that were added are: 

| svt flag   |   description  |  libaom equivalent |
|----------|:-------------:|------:|
| `--profile` | Bitstream profile number to use   | `--profile` |
| `--tile-columns`|   log2 of tile columns    |   `--tile-columns` |
| `--enable-altref` | Enable automatic alt reference frames.  |    `--auto-alt-ref` |
| `--altref-strength` | AltRef filter strength |    `--arnr-strength` |
| `--altref-nframes` | AltRef max frames |    `--arnr-maxframes` |
