### PR TITLE
Add option to use qp values instead of bitrates as data points.

### DIFF
--- a/rtc-video-quality/encoder_commands.py
+++ b/rtc-video-quality/encoder_commands.py
@@ -51,12 +51,12 @@ def rav1e_command(job, temp_dir):
 
     if job['param'] == 'bitrate':
         assert len(job['target_bitrates_kbps'])
-        param = [
+        control_params = [
             '--bitrate', job['target_bitrates_kbps'][-1]
         ]
     else:
         assert job['qp_value'] != -1
-        param = [
+        control_params = [
             '--quantizer', (job['qp_value'] * 4)
         ]
 
@@ -81,7 +81,7 @@ def rav1e_command(job, temp_dir):
             '--keyint', '1'
         ]
 
-    command = [binary_vars.RAV1E_ENC_BIN] + codec_params + param + common_params
+    command = [binary_vars.RAV1E_ENC_BIN] + codec_params + control_params + common_params
 
     command = [str(flag) for flag in command]
 
@@ -115,13 +115,13 @@ def svt_command(job, temp_dir):
 
     if job['param'] == 'bitrate':
         assert len(job['target_bitrates_kbps'])
-        param = [
+        control_params = [
             '--tbr', job['target_bitrates_kbps'][0],
             '--rc', 1
         ]
     else:
         assert job['qp_value'] != -1
-        param = [
+        control_params = [
             '--rc', '0',
             '-q', job['qp_value'],
             '--min-qp', job['qp_value'],
@@ -177,14 +177,14 @@ def svt_command(job, temp_dir):
         ]
 
     if 'offline' in encoder:
-        first_pass_command = [ binary_vars.SVT_ENC_BIN ] + first_pass_params + param + common_params
-        second_pass_command = [ binary_vars.SVT_ENC_BIN ] + second_pass_params + param + common_params
+        first_pass_command = [ binary_vars.SVT_ENC_BIN ] + first_pass_params + control_params + common_params
+        second_pass_command = [ binary_vars.SVT_ENC_BIN ] + second_pass_params + control_params + common_params
 
         command = first_pass_command + ['&&'] + second_pass_command
 
     else:
 
-        command = [binary_vars.SVT_ENC_BIN] + codec_params + param + common_params
+        command = [binary_vars.SVT_ENC_BIN] + codec_params + control_params + common_params
 
     command = [str(flag) for flag in command]
 
@@ -220,13 +220,13 @@ def aom_command(job, temp_dir):
 
     if job['param'] == 'bitrate':
         assert len(job['target_bitrates_kbps'])
-        param = [
+        control_params = [
             '--target-bitrate=%d' % job['target_bitrates_kbps'][0],
             '--end-usage=cbr'
         ]
     else:
         assert job['qp_value'] != -1
-        param = [
+        control_params = [
             '--min-q=%d' % job['qp_value'],
             '--max-q=%d' % (job['qp_value'] + 8),
             '--end-usage=q'
@@ -311,7 +311,7 @@ def aom_command(job, temp_dir):
             "--profile=0"
         ]
 
-    command = [binary_vars.AOM_ENC_BIN] + codec_params + param + common_params
+    command = [binary_vars.AOM_ENC_BIN] + codec_params + control_params + common_params
 
     encoded_files = [{'spatial-layer': 0,
                       'temporal-layer': 0, 'filename': encoded_filename}]

--- a/rtc-video-quality/encoder_commands.py
+++ b/rtc-video-quality/encoder_commands.py
@@ -46,9 +46,19 @@ def rav1e_command(job, temp_dir):
     common_params = [
         '-y',
         '--output', encoded_filename,
-        '--bitrate', job['target_bitrates_kbps'][0],
         clip['y4m_file']
     ]
+
+    if job['param'] == 'bitrate':
+        assert not job['target_bitrates_kbps']
+        param = [
+            '--bitrate', job['target_bitrates_kbps'][-1]
+        ]
+    else:
+        assert job['qp_value'] != -1
+        param = [
+            '--quantizer', (job['qp_value'] * 4)
+        ]
 
 
     encoder = job['encoder']
@@ -71,7 +81,7 @@ def rav1e_command(job, temp_dir):
             '--keyint', '1'
         ]
 
-    command = [binary_vars.RAV1E_ENC_BIN] + codec_params + common_params
+    command = [binary_vars.RAV1E_ENC_BIN] + codec_params + param + common_params
 
     command = [str(flag) for flag in command]
 
@@ -101,8 +111,23 @@ def svt_command(job, temp_dir):
         '-h', clip['height'],
         '-i', clip['yuv_file'],
         '-b', encoded_filename,
-        '--tbr', job['target_bitrates_kbps'][0]
     ]
+
+    if job['param'] == 'bitrate':
+        assert not job['target_bitrates_kbps']
+        param = [
+            '--tbr', job['target_bitrates_kbps'][0],
+            '--rc', 1
+        ]
+    else:
+        assert job['qp_value'] != -1
+        param = [
+            '--rc', '0',
+            '-q', job['qp_value'],
+            '--min-qp', job['qp_value'],
+            '--max-qp', (job['qp_value'] + 8),
+            '--keyint', (INTRA_IVAL_LOW_LATENCY - 1)
+        ]
 
     encoder = job['encoder']
 
@@ -152,14 +177,14 @@ def svt_command(job, temp_dir):
         ]
 
     if 'offline' in encoder:
-        first_pass_command = [ binary_vars.SVT_ENC_BIN ] + first_pass_params + common_params
-        second_pass_command = [ binary_vars.SVT_ENC_BIN ] + second_pass_params + common_params
+        first_pass_command = [ binary_vars.SVT_ENC_BIN ] + first_pass_params + param + common_params
+        second_pass_command = [ binary_vars.SVT_ENC_BIN ] + second_pass_params + param + common_params
 
         command = first_pass_command + ['&&'] + second_pass_command
 
     else:
 
-        command = [binary_vars.SVT_ENC_BIN] + codec_params + common_params
+        command = [binary_vars.SVT_ENC_BIN] + codec_params + param + common_params
 
     command = [str(flag) for flag in command]
 
@@ -190,9 +215,22 @@ def aom_command(job, temp_dir):
         '--width=%d' % clip['width'],
         '--height=%d' % clip['height'],
         '--output=%s' % encoded_filename,
-        '--target-bitrate=%d' % job['target_bitrates_kbps'][0],
         clip['yuv_file']
     ]
+
+    if job['param'] == 'bitrate':
+        assert not job['target_bitrates_kbps']
+        param = [
+            '--target-bitrate=%d' % job['target_bitrates_kbps'][0],
+            '--end-usage=cbr'
+        ]
+    else:
+        assert job['qp_value'] != -1
+        param = [
+            '--min-q=%d' % job['qp_value'],
+            '--max-q=%d' % (job['qp_value'] + 8),
+            '--end-usage=q'
+        ]
 
     encoder = job['encoder']
 
@@ -273,7 +311,7 @@ def aom_command(job, temp_dir):
             "--profile=0"
         ]
 
-    command = [binary_vars.AOM_ENC_BIN] + codec_params + common_params
+    command = [binary_vars.AOM_ENC_BIN] + codec_params + param + common_params
 
     encoded_files = [{'spatial-layer': 0,
                       'temporal-layer': 0, 'filename': encoded_filename}]

--- a/rtc-video-quality/encoder_commands.py
+++ b/rtc-video-quality/encoder_commands.py
@@ -50,7 +50,7 @@ def rav1e_command(job, temp_dir):
     ]
 
     if job['param'] == 'bitrate':
-        assert not job['target_bitrates_kbps']
+        assert len(job['target_bitrates_kbps'])
         param = [
             '--bitrate', job['target_bitrates_kbps'][-1]
         ]
@@ -114,7 +114,7 @@ def svt_command(job, temp_dir):
     ]
 
     if job['param'] == 'bitrate':
-        assert not job['target_bitrates_kbps']
+        assert len(job['target_bitrates_kbps'])
         param = [
             '--tbr', job['target_bitrates_kbps'][0],
             '--rc', 1
@@ -219,7 +219,7 @@ def aom_command(job, temp_dir):
     ]
 
     if job['param'] == 'bitrate':
-        assert not job['target_bitrates_kbps']
+        assert len(job['target_bitrates_kbps'])
         param = [
             '--target-bitrate=%d' % job['target_bitrates_kbps'][0],
             '--end-usage=cbr'

--- a/rtc-video-quality/generate_data.py
+++ b/rtc-video-quality/generate_data.py
@@ -417,7 +417,7 @@ def run_command(job, encoder_command, job_temp_dir, encoded_file_dir):
 
 
 def find_qp():
-    return [ 35, 40, 45, 48, 53, 55 ]
+    return [35, 40, 45, 48, 53, 55]
 
 
 def find_bitrates(width, height):
@@ -508,10 +508,12 @@ def start_daemon(func):
 
 
 def job_to_string(job):
+    param = ":".join(str(i) for i in job['target_bitrates_kbps']
+                    ) if job['param'] == 'bitrate' else job['qp_value']
     return "%s:%s %dsl%dtl %s %s" % (
         job['encoder'], job['codec'], job['num_spatial_layers'],
-        job['num_temporal_layers'], ":".join(
-            str(i) for i in job['target_bitrates_kbps']),
+        job['num_temporal_layers'], 
+        param,
         os.path.basename(job['clip']['input_file']))
 
 

--- a/rtc-video-quality/generate_data.py
+++ b/rtc-video-quality/generate_data.py
@@ -417,7 +417,7 @@ def run_command(job, encoder_command, job_temp_dir, encoded_file_dir):
 
 
 def find_qp():
-    return [35, 40, 43, 46, 49, 50, 53, 55]
+    return [ 35, 40, 45, 48, 53, 55 ]
 
 
 def find_bitrates(width, height):


### PR DESCRIPTION
Since we will also be using qp values, add qp_values to be as datapoints.  
Thus, we add an option on whether to use target bitrate or qp_values and 
set qp_values as default. If you want to enable bitrate, you can use `--enable-bitrate` flag.  

For the encoders, adapt and use flags based on the type of datapoint. 
 